### PR TITLE
native GDML writer addition

### DIFF
--- a/simulation/g4simulation/g4gdml/PHG4GDMLUtility.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLUtility.cc
@@ -21,6 +21,7 @@
 #include <phool/getClass.h>
 
 #include <Geant4/G4VPhysicalVolume.hh>
+#include <Geant4/G4GDMLWriteStructure.hh>
 
 #include <cassert>
 #include <iostream>  // for operator<<, stringstream
@@ -42,6 +43,31 @@ void PHG4GDMLUtility::Dump_GDML(const std::string &filename, G4VPhysicalVolume *
   assert(config);
 
   PHG4GDMLWriteStructure gdml_parser(config);
+  assert(vol);
+  assert(vol->GetLogicalVolume());
+
+  xercesc::XMLPlatformUtils::Initialize();
+  gdml_parser.Write(filename, vol->GetLogicalVolume(), get_PHG4GDML_Schema(), 0, true);
+  xercesc::XMLPlatformUtils::Terminate();
+}
+
+void PHG4GDMLUtility::Dump_G4_GDML(const std::string &filename, G4VPhysicalVolume *vol, PHCompositeNode *topNode)
+{
+  if (topNode == nullptr)
+  {
+    Fun4AllServer *se = Fun4AllServer::instance();
+    topNode = se->topNode();
+  }
+
+  const PHG4GDMLConfig *config =
+      GetOrMakeConfigNode(topNode);
+  assert(config);
+
+  // PHG4GDMLWriteStructure gdml_parser(config);
+  // assert(vol);
+  // assert(vol->GetLogicalVolume());
+
+  G4GDMLWriteStructure gdml_parser;
   assert(vol);
   assert(vol->GetLogicalVolume());
 

--- a/simulation/g4simulation/g4gdml/PHG4GDMLUtility.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLUtility.cc
@@ -51,21 +51,8 @@ void PHG4GDMLUtility::Dump_GDML(const std::string &filename, G4VPhysicalVolume *
   xercesc::XMLPlatformUtils::Terminate();
 }
 
-void PHG4GDMLUtility::Dump_G4_GDML(const std::string &filename, G4VPhysicalVolume *vol, PHCompositeNode *topNode)
+void PHG4GDMLUtility::Dump_G4_GDML(const std::string &filename, G4VPhysicalVolume *vol)
 {
-  if (topNode == nullptr)
-  {
-    Fun4AllServer *se = Fun4AllServer::instance();
-    topNode = se->topNode();
-  }
-
-  const PHG4GDMLConfig *config =
-      GetOrMakeConfigNode(topNode);
-  assert(config);
-
-  // PHG4GDMLWriteStructure gdml_parser(config);
-  // assert(vol);
-  // assert(vol->GetLogicalVolume());
 
   G4GDMLWriteStructure gdml_parser;
   assert(vol);

--- a/simulation/g4simulation/g4gdml/PHG4GDMLUtility.hh
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLUtility.hh
@@ -28,6 +28,9 @@ class PHG4GDMLUtility
   //! save the current Geant4 geometry to GDML file. Reading PHG4GDMLConfig from topNode
   static void Dump_GDML(const std::string &filename, G4VPhysicalVolume *vol, PHCompositeNode *topNode = nullptr);
 
+  //! same as above but use default Geant functions as much as possible
+  static void Dump_G4_GDML(const std::string &filename, G4VPhysicalVolume *vol, PHCompositeNode *topNode = nullptr);
+
   static constexpr const char *get_PHG4GDML_Schema()
   {
     return "http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd";

--- a/simulation/g4simulation/g4gdml/PHG4GDMLUtility.hh
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLUtility.hh
@@ -29,7 +29,7 @@ class PHG4GDMLUtility
   static void Dump_GDML(const std::string &filename, G4VPhysicalVolume *vol, PHCompositeNode *topNode = nullptr);
 
   //! same as above but use default Geant functions as much as possible
-  static void Dump_G4_GDML(const std::string &filename, G4VPhysicalVolume *vol, PHCompositeNode *topNode = nullptr);
+  static void Dump_G4_GDML(const std::string &filename, G4VPhysicalVolume *vol);
 
   static constexpr const char *get_PHG4GDML_Schema()
   {

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -579,6 +579,13 @@ void PHG4Reco::Dump_GDML(const std::string &filename)
   PHG4GDMLUtility ::Dump_GDML(filename, m_Detector->GetPhysicalVolume());
 }
 
+//________________________________________________________________
+//Dump TGeo File using native Geant4 tools
+void PHG4Reco::Dump_G4_GDML(const std::string &filename)
+{
+  PHG4GDMLUtility::Dump_G4_GDML(filename, m_Detector->GetPhysicalVolume());
+}
+
 //_________________________________________________________________
 int PHG4Reco::ApplyCommand(const std::string &cmd)
 {

--- a/simulation/g4simulation/g4main/PHG4Reco.h
+++ b/simulation/g4simulation/g4main/PHG4Reco.h
@@ -117,6 +117,7 @@ class PHG4Reco : public SubsysReco
   PHG4Subsystem *getSubsystem(const std::string &name);
   PHG4DisplayAction *GetDisplayAction() { return m_DisplayAction; }
   void Dump_GDML(const std::string &filename);
+  void Dump_G4_GDML(const std::string &filename);
 
   void G4Verbosity(const int i);
 


### PR DESCRIPTION
Added a function `PHG4GDMLUtility::Dump_G4_GDML` and corresponding `PHG4Reco::Dump_G4_GDML` that uses `G4GDMLWriteStructure` instead of `PHG4GDMLWriteStructure`. This way patches and version updates to geant get picked up without having to be ported in. 

The name isn't great, I'm open to suggestions :)