### PR TITLE
Adding calorimeters in the Far Backward region

### DIFF
--- a/offline/packages/CaloBase/RawTowerDefs.h
+++ b/offline/packages/CaloBase/RawTowerDefs.h
@@ -41,7 +41,12 @@ namespace RawTowerDefs
     LFHCAL = 11,
     BECAL = 12,
     ZDC = 13,
-    B0ECAL = 14
+    B0ECAL = 14,
+    BWD_0 = 15,
+    BWD_1 = 16,
+    BWD_2 = 17,
+    BWD_3 = 18,
+    BWD_4 = 19
   };
 
   /*! Returns CaloTowerID for given calorimeter ID, tower index 1, and tower index 2
@@ -254,6 +259,26 @@ namespace RawTowerDefs
       return "B0ECAL";
       break;
   
+    case BWD_0:
+      return "BWD_0";
+      break;
+  
+    case BWD_1:
+      return "BWD_1";
+      break;
+  
+    case BWD_2:
+      return "BWD_2";
+      break;
+  
+    case BWD_3:
+      return "BWD_3";
+      break;
+  
+    case BWD_4:
+      return "BWD_4";
+      break;
+  
     default:
       std::cout
           << "Invalid calorimeter ID passed to RawTowerDefs::convert_caloid_to_name"
@@ -311,6 +336,21 @@ namespace RawTowerDefs
 
     else if (caloname == "B0ECAL")
       return B0ECAL;
+
+    else if (caloname == "BWD_0")
+      return BWD_0;
+
+    else if (caloname == "BWD_1")
+      return BWD_1;
+
+    else if (caloname == "BWD_2")
+      return BWD_2;
+
+    else if (caloname == "BWD_3")
+      return BWD_3;
+
+    else if (caloname == "BWD_4")
+      return BWD_4;
 
     else
     {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
RawTowerDefs.h changed to add calorimeters in the far backward region for the Low Q2 taggers and Luminometers.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

